### PR TITLE
Autostart pico by default (without automatic nano upgrade)

### DIFF
--- a/client/src/NetworkClient.ts
+++ b/client/src/NetworkClient.ts
@@ -136,12 +136,16 @@ class NetworkClient {
         this._eventClient.off(event, callback);
     }
 
-    public async disconnect(): Promise<boolean> {
-        return this._eventClient.call('disconnect');
+    public async connectNano(): Promise<boolean> {
+        return this._eventClient.call('connectNano');
     }
 
     public async connectPico(addresses?: string[], upgradeToNano?: boolean): Promise<Map<string, number>> {
         return this._eventClient.call('connectPico', addresses, upgradeToNano);
+    }
+
+    public async disconnect(): Promise<boolean> {
+        return this._eventClient.call('disconnect');
     }
 
     public async relayTransaction(txObj: PlainTransaction): Promise<boolean> {

--- a/client/src/NetworkClient.ts
+++ b/client/src/NetworkClient.ts
@@ -140,8 +140,8 @@ class NetworkClient {
         return this._eventClient.call('disconnect');
     }
 
-    public async connectPico(addresses: string[]): Promise<Map<string, number>> {
-        return this._eventClient.call('connectPico', addresses);
+    public async connectPico(addresses?: string[], upgradeToNano?: boolean): Promise<Map<string, number>> {
+        return this._eventClient.call('connectPico', addresses, upgradeToNano);
     }
 
     public async relayTransaction(txObj: PlainTransaction): Promise<boolean> {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "rollup-plugin-node-resolve": "^3.3.0"
   },
   "dependencies": {
-    "@nimiq/nano-api": "^0.2.2",
+    "@nimiq/nano-api": "^0.3.0",
     "@nimiq/rpc-events": "^0.0.8",
     "@nimiq/utils": "^0.0.2"
   }

--- a/src/autorun.js
+++ b/src/autorun.js
@@ -2,4 +2,4 @@ import { Network } from './network';
 import { Config } from '@nimiq/utils';
 
 const network = new Network(Config);
-network.connect().catch(console.error);
+network.connectPico([], false).catch(console.error);

--- a/src/network.js
+++ b/src/network.js
@@ -10,7 +10,8 @@ export class Network extends NanoNetworkApi {
         this._eventServer = new EventServer();
 
         // Register RPC calls.
-        this._eventServer.onRequest('disconnect', (state) => this.disconnect());
+        this._eventServer.onRequest('connectNano', () => this.connect());
+        this._eventServer.onRequest('disconnect', () => this.disconnect());
         this._eventServer.onRequest('connectPico',
             (state, userFriendlyAddresses, upgradeToNano) => this.connectPico(userFriendlyAddresses, upgradeToNano));
         this._eventServer.onRequest('relayTransaction', (state, arg) => this.relayTransaction(arg));

--- a/src/network.js
+++ b/src/network.js
@@ -11,7 +11,8 @@ export class Network extends NanoNetworkApi {
 
         // Register RPC calls.
         this._eventServer.onRequest('disconnect', (state) => this.disconnect());
-        this._eventServer.onRequest('connectPico', (state, arg) => this.connectPico(arg));
+        this._eventServer.onRequest('connectPico',
+            (state, userFriendlyAddresses, upgradeToNano) => this.connectPico(userFriendlyAddresses, upgradeToNano));
         this._eventServer.onRequest('relayTransaction', (state, arg) => this.relayTransaction(arg));
         this._eventServer.onRequest('getTransactionSize', (state, arg) => this.getTransactionSize(arg));
         this._eventServer.onRequest('subscribe', (state, arg) => this.subscribe(arg));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@nimiq/nano-api@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@nimiq/nano-api/-/nano-api-0.2.2.tgz#a060d1c3c290f9a3838713183b29b34c98eb2840"
-  integrity sha512-1QgKM185suV+QS74VxAliWs1kjRHrZc3cEmQobLdyiMeJB5my1Ge/oiK8QRoCCyUX1VcLlkKKtyqJdW3/iuFpg==
+"@nimiq/nano-api@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@nimiq/nano-api/-/nano-api-0.3.0.tgz#094f613d432d1dc9ab34068b8100845bccfdf4b7"
+  integrity sha512-qc2rSS8xYq4ecaiaA57OvCbepFURZ1320RZ6SrUwPlvh3bDBqC8S/nUJM4d0tz5dYAYeE1yLNGTd7/5OeG3fWA==
   dependencies:
     "@nimiq/utils" "^0.0.2"
 


### PR DESCRIPTION
Requires a nano-api package update before merging.