### PR TITLE
Use default endpoint network.nimiq.com for all nimiq.com domains

### DIFF
--- a/client/src/NetworkClient.ts
+++ b/client/src/NetworkClient.ts
@@ -55,7 +55,7 @@ class NetworkClient {
     private static _instance: NetworkClient | null = null;
 
     private static readonly DEFAULT_ENDPOINT =
-        window.location.origin === 'https://accounts.nimiq.com'
+        window.location.origin.endsWith('nimiq.com')
             ? 'https://network.nimiq.com'
             : 'https://network.nimiq-testnet.com';
 


### PR DESCRIPTION
While the Accounts Manager uses the endpoint specified in a config file, the safe uses the default endpoint as far as I know.
When deployed on main net, the safe would currently use the testnet network with the current implementation though.